### PR TITLE
Use the Room object as the sender instead of the Websocket

### DIFF
--- a/Assets/Plugins/Colyseus/Room.cs
+++ b/Assets/Plugins/Colyseus/Room.cs
@@ -95,13 +95,13 @@ namespace Colyseus
 
 			this.connection.OnClose += (object sender, EventArgs e) => {
 				if (this.OnLeave != null) {
-					this.OnLeave.Invoke (sender, e);
+					this.OnLeave.Invoke (this, e);
 				}
 			};
 
 			this.connection.OnError += (object sender, ErrorEventArgs e) => {
 				if (this.OnError != null) {
-					this.OnError.Invoke(sender, e);
+					this.OnError.Invoke(this, e);
 				}
 			};
 


### PR DESCRIPTION
The OnLeaveRoom function in Client.cs relies on the sender to be the Room to be able to remove the room from the client's room list. Since it was previously passing the Websocket, it was always throwing an error.