### PR TITLE
Set the type for onError to ErrorEventArgs

### DIFF
--- a/Assets/Plugins/Colyseus/Client.cs
+++ b/Assets/Plugins/Colyseus/Client.cs
@@ -49,7 +49,7 @@ namespace Colyseus
 		/// <summary>
 		/// Occurs when the <see cref="Client"/> gets an error.
 		/// </summary>
-		public event EventHandler OnError;
+		public event EventHandler<ErrorEventArgs> OnError;
 
 		/// <summary>
 		/// Occurs when the <see cref="Client"/> receives a message from server.


### PR DESCRIPTION
**PROBLEM:** I was unable to get the error message when tapping into `onError`

**SOLUTION:** Set the type as `ErrorEventArgs` to be able to access `e.message`

```
client.OnError += (object sender, ErrorEventArgs e) => {
	Debug.Log(e.message);
};
```